### PR TITLE
Initialize WebHaptics instance eagerly

### DIFF
--- a/packages/web-haptics/src/react/useWebHaptics.ts
+++ b/packages/web-haptics/src/react/useWebHaptics.ts
@@ -11,8 +11,11 @@ import type {
 export function useWebHaptics(options?: WebHapticsOptions) {
   const instanceRef = useRef<WebHaptics | null>(null);
 
-  useEffect(() => {
+  if (instanceRef.current === null) {
     instanceRef.current = new WebHaptics(options);
+  }
+
+  useEffect(() => {
     return () => {
       instanceRef.current?.destroy();
       instanceRef.current = null;


### PR DESCRIPTION
Previously the instance was created inside `useEffect`, meaning it wasn't available until after paint. This changes make `WebHaptics` available immediately.

Since the `WebHaptics` class does not use any web APIs in the constructor, it's safe to create it eagerly.

Relevant React documentation:

- https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents
- https://18.react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents

React Compiler ready: https://playground.react.dev/#N4Igzg9grgTgxgUxALhAHRFMCAEcA2AlggHYAuGA3GiTYQLYAOEMZOwOWCASggGYAaTtgCifPgjhkhXAMIBDfPgBG8uAGscAXxx8YEejgwwEaiiGokGzVuxwB1BMoAS8xmUJww23fsMYAOgCAeiJlYIB3JwBaAAs3Dy8qOiYWNjIAT0ZcYBocHFd3TwBJEkYoaTycABUYQgBzeoQYAHkiiBIwASrHFwTPMDaPDq6aHT0DIxAg0MJwqOU4-q9gzOywZNoSBAAPGzY+KBIpQg7hBF7CxLAACgh2zoB+ZAcnK4Gh086ASnYquBGbEInTI8mOPH4OAAvOdeHwADyXZbeAA+OBIUCUAD4bhilN9LFVCHwcDdgWBQeC4QE4LATORoVCYXj8L9ciR8vlyZTENTaTB6WxmQgIq8+kUvHcHmACVUtDQqlwxBIpDcbr8oVi-hzOSYyLAOeroVr2ZzOdywbz+DS6aQyI8AgATBAU-QZdWWM1ckGWiF8G0Cu3Q9GY-CezlacNaIQAbQAurKtvkleJJGQ1RqTVVvRTfXzbeQHdgyAARJxQepS4ZPJ3l+o4R6PXSKbCJ-LRnAx+7VsAO53KCsJwk6lMq9NGzXas0WqnW-mCosIMgAZViEAiy4ihDIcFiVa+vYCYDXG63O9iDabfBbCDb2lj3YPRZPm+3u6HCp1AJBODIdUazTBnIigqGo6g3NmpLAuU9ovO8cClDBQiPiMzw1P+TStNKmaQTmPJ+gGC4BH+DSYWSZQVMh2HdDq+TxjR+SJv8gJ4L6+BAdgChKKoGgZsaOAzla-rznaDpwGx6qxh+SZ4CxhBgMuUCMPsCCOsGSISmAATyYpylpKpw75HqBp2CRAEwEI4ngvgQg6UpKlqZGYwgAIIDfnwDQoCA1hpL+WQ5DgAAK+AVsCnwjD4EyGAA5KoygIPg0SMCF9TAtEJhmNEAJMIQ+DNMEjryWQ0XDjcpo4MEwTZYwuXyNWACyEDOi8GAgRgYw4GAdXyR5LpBSlYXYZQLngCepRkM0JAtig174NgWhAA