### PR TITLE
fix: fix svelte export

### DIFF
--- a/packages/web-haptics/package.json
+++ b/packages/web-haptics/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "rm -rf dist && tsup",
     "dev": "tsup --watch",
     "lint": "eslint -c .eslintrc.cjs ./src/**/*.{ts,tsx}",
     "lint:fix": "eslint --fix -c .eslintrc.cjs ./src/**/*.{ts,tsx}",

--- a/packages/web-haptics/tsup.config.ts
+++ b/packages/web-haptics/tsup.config.ts
@@ -9,7 +9,6 @@ export default defineConfig((options) => [
     },
     format: ["cjs", "esm"],
     dts: true,
-    clean: true,
     sourcemap: false,
     target: "es2022",
     external: ["react"],


### PR DESCRIPTION
The root cause was clean: true in the first tsup config (Core + React). Since tsup runs all three
   configs in parallel, the Svelte DTS files would finish generating first, then get wiped when the
   Core + React config cleaned the dist/ folder.

  The fix was two changes:

  1. Removed clean: true from tsup.config.ts
  2. Changed the build script to rm -rf dist && tsup so the dist folder is cleaned once before all
  configs run
  
  before:
<img width="331" height="302" alt="Scherm­afbeelding 2026-03-03 om 16 23 26" src="https://github.com/user-attachments/assets/928e311f-a397-460e-bbc0-f92a8dc55fa7" />

after: 


  
<img width="305" height="344" alt="Scherm­afbeelding 2026-03-03 om 16 30 07" src="https://github.com/user-attachments/assets/10f6713a-9790-45a1-80db-e6bd4e9763e6" />

  