### PR TITLE
docs: update dependency install commands

### DIFF
--- a/site/src/surfaces/installation/index.tsx
+++ b/site/src/surfaces/installation/index.tsx
@@ -9,9 +9,9 @@ import { useHaptics } from "../../hooks/useHaptics";
 
 const pkgCmds = {
   npm: "npm i web-haptics",
-  pnpm: "pnpm i web-haptics",
+  pnpm: "pnpm add web-haptics",
   yarn: "yarn add web-haptics",
-  bun: "bun i web-haptics",
+  bun: "bun add web-haptics",
 };
 
 export const InstallCommands = () => {


### PR DESCRIPTION
This pull request updates the installation command for `pnpm`  and `bun` by changing the `install` command to `add`. The `install` command is used to install all the dependencies ( [pnpm install ](https://pnpm.io/cli/install), [bun install](https://bun.com/docs/pm/cli/install) ) in a project while the `add` command is used to add dependencies to a project ( [pnpm add](https://pnpm.io/cli/add), [bun add](https://bun.com/docs/pm/cli/add) ).