### PR TITLE
Bring default error pattern closer to HIG

### DIFF
--- a/packages/web-haptics/src/lib/web-haptics/patterns.ts
+++ b/packages/web-haptics/src/lib/web-haptics/patterns.ts
@@ -19,9 +19,10 @@ export const defaultPatterns = {
   error: {
     // three rapid harsh taps indicating an error.
     pattern: [
-      { duration: 40, intensity: 0.9 },
+      { duration: 40, intensity: 0.7 },
+      { delay: 40, duration: 40, intensity: 0.7 },
       { delay: 40, duration: 40, intensity: 0.9 },
-      { delay: 40, duration: 40, intensity: 0.9 },
+      { delay: 40, duration: 50, intensity: 0.6 },
     ],
   },
 


### PR DESCRIPTION
I understand the default haptics are meant to follow Apple’s Human Interface Guidelines.

The default error haptics currently play three taps of equal intensity and duration.

But the HIG error haptics play four taps of varying intensity and duration. [See this video](https://docs-assets.developer.apple.com/published/56a07a13c46578183f9caeafedd22943/error~dark.mp4) from the [HIG docs](https://developer.apple.com/design/human-interface-guidelines/playing-haptics\#Notification) (the third one).

This PR adjusts the default error haptics to bring them closer to the HIG standard.
