### PR TITLE
feat: type-safe default patterns

### DIFF
--- a/packages/web-haptics/src/index.ts
+++ b/packages/web-haptics/src/index.ts
@@ -9,4 +9,5 @@ export type {
   HapticInput,
   TriggerOptions,
   WebHapticsOptions,
+  DefaultPattern,
 } from "./lib/web-haptics/types";

--- a/packages/web-haptics/src/lib/web-haptics/types.ts
+++ b/packages/web-haptics/src/lib/web-haptics/types.ts
@@ -1,3 +1,5 @@
+import type { defaultPatterns } from "./patterns";
+
 export interface Vibration {
   duration: number;
   intensity?: number;
@@ -10,7 +12,14 @@ export interface HapticPreset {
   pattern: Vibration[];
 }
 
-export type HapticInput = number | string | HapticPattern | HapticPreset;
+export type DefaultPattern = keyof typeof defaultPatterns;
+
+export type HapticInput =
+  | number
+  | DefaultPattern
+  | (string & {})
+  | HapticPattern
+  | HapticPreset;
 
 export interface TriggerOptions {
   intensity?: number;

--- a/packages/web-haptics/src/svelte/types.ts
+++ b/packages/web-haptics/src/svelte/types.ts
@@ -5,4 +5,5 @@ export type {
   HapticInput,
   TriggerOptions,
   WebHapticsOptions,
+  DefaultPattern,
 } from "../lib/web-haptics/types";

--- a/packages/web-haptics/src/vue/types.ts
+++ b/packages/web-haptics/src/vue/types.ts
@@ -5,4 +5,5 @@ export type {
   HapticInput,
   TriggerOptions,
   WebHapticsOptions,
+  DefaultPattern,
 } from "../lib/web-haptics/types";


### PR DESCRIPTION
Adds type-safe autocomplete for default pattern names when passing a string to `trigger()`. Arbitrary strings are still accepted to maintain backwards compatibility :)