### PR TITLE
update: skill with presets and defaultPatterns

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -85,6 +85,19 @@ haptics.trigger("success");
 Next.js: add "use client" to any component using useWebHaptics().
 Nuxt/SvelteKit: works directly, library handles SSR.
 
+## Trigger Presets & defaultPatterns
+
+All named string presets have a corresponding object in `defaultPatterns`. Use when you need to pass a preset as a value rather than a string literal:
+
+```ts
+import { WebHaptics, defaultPatterns } from 'web-haptics'
+
+const haptics = new WebHaptics()
+haptics.trigger(defaultPatterns.light)
+```
+
+Extra presets not listed above: `"soft"`, `"rigid"`, `"nudge"`, `"buzz"`. See `defaultPatterns` for all available values.
+
 ## Apple HIG Design Rules -- FOLLOW THESE
 
 1. Haptics supplement, never replace. Always pair with visual feedback. UI must work fully without haptics.


### PR DESCRIPTION
# Why?
When installing and using the lib for the first (using the skill) **agents were not aware of defaultPatterns object and how to use it**.

Agents ended up creating their own light, medium patterns. I had to take a look into the lib to find out that default patterns already exist.

This will help agents know about the presets.