### PR TITLE
Add standalone IIFE build for `<script>` tag usage

### DIFF
--- a/packages/web-haptics/README.md
+++ b/packages/web-haptics/README.md
@@ -57,6 +57,23 @@ const haptics = new WebHaptics();
 haptics.trigger("success");
 ```
 
+## Standalone `<script>` Tag
+
+You can use web-haptics directly in the browser without any build tools:
+
+```html
+<script src="https://unpkg.com/web-haptics/dist/web-haptics.global.js"></script>
+<script>
+  const haptics = new WebHaptics();
+  haptics.trigger("success");
+</script>
+```
+
+The script tag makes the following globals available:
+- `WebHaptics` — the main class
+- `WebHapticsLib.defaultPatterns` — built-in haptic presets
+- `WebHapticsLib.version` — library version
+
 ## Built-in Presets
 
 | Name      | Pattern                                                          | Description                    |

--- a/packages/web-haptics/README.md
+++ b/packages/web-haptics/README.md
@@ -62,7 +62,7 @@ haptics.trigger("success");
 You can use web-haptics directly in the browser without any build tools:
 
 ```html
-<script src="https://unpkg.com/web-haptics/dist/web-haptics.global.js"></script>
+<script src="/path/to/web-haptics.global.js"></script>
 <script>
   const haptics = new WebHaptics();
   haptics.trigger("success");

--- a/packages/web-haptics/package.json
+++ b/packages/web-haptics/package.json
@@ -12,6 +12,8 @@
     "directory": "packages/web-haptics"
   },
   "types": "dist/index.d.ts",
+  "unpkg": "dist/web-haptics.global.js",
+  "jsdelivr": "dist/web-haptics.global.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/web-haptics/tsup.config.ts
+++ b/packages/web-haptics/tsup.config.ts
@@ -40,4 +40,18 @@ export default defineConfig((options) => [
     external: ["svelte"],
     minify: !options.watch,
   },
+  // Standalone IIFE for <script> tag usage
+  {
+    entry: {
+      "web-haptics": "src/index.ts",
+    },
+    format: ["iife"],
+    globalName: "WebHapticsLib",
+    sourcemap: false,
+    target: "es2017",
+    minify: !options.watch,
+    footer: {
+      js: `if(typeof window!=="undefined"){window.WebHaptics=WebHapticsLib.WebHaptics;window.WebHapticsLib=WebHapticsLib;}`,
+    },
+  },
 ]);


### PR DESCRIPTION
Adds a browser-ready IIFE bundle so **web-haptics** can be used directly via `<script>` tag without bundlers or build tools.

### Changes
* **`tsup.config.ts`** - New IIFE build entry targeting ES2017, outputs `dist/web-haptics.global.js`. Exposes `window.WebHaptics` (class shortcut) and `window.WebHapticsLib` (full module with `defaultPatterns`, `version`)
* **`package.json`** - Added `unpkg` and `jsdelivr` fields for CDN auto-resolution
* **`README.md`** - Documented `<script>` tag usage

### Usage
```html
<script src="/path/to/web-haptics.global.js"></script>
<script>
  const haptics = new WebHaptics();
  haptics.trigger("success");
</script>
```