### PR TITLE
fix:update isSupported check to expand detection of mobile devices

### DIFF
--- a/packages/web-haptics/README.md
+++ b/packages/web-haptics/README.md
@@ -112,7 +112,7 @@ Show or hide the haptic feedback toggle switch.
 
 ### `WebHaptics.isSupported`
 
-Static boolean — `true` if the device supports the Vibration API.
+Static boolean — `true` if the device supports haptics (touch devices such as iOS and Android).
 
 ## License
 

--- a/packages/web-haptics/README.md
+++ b/packages/web-haptics/README.md
@@ -112,7 +112,7 @@ Show or hide the haptic feedback toggle switch.
 
 ### `WebHaptics.isSupported`
 
-Static boolean — `true` if the device supports haptics (touch devices such as iOS and Android).
+Static boolean — `true` if the device supports haptics (iPhone and Android). Returns `false` on iPad/iPadOS, desktop, and other non-mobile platforms.
 
 ## License
 

--- a/packages/web-haptics/src/lib/web-haptics/index.ts
+++ b/packages/web-haptics/src/lib/web-haptics/index.ts
@@ -155,15 +155,35 @@ export class WebHaptics {
   private static readonly supportsVibrationAPI: boolean =
     typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
 
-  static readonly isSupported: boolean =
-    typeof navigator !== "undefined" &&
-    (typeof navigator.vibrate === "function" ||
-      navigator.maxTouchPoints > 0);
+  private static readonly isMobileDevice: boolean = (() => {
+    if (typeof navigator === "undefined") return false;
+    if (navigator.maxTouchPoints <= 0) return false;
+
+    if ("userAgentData" in navigator) {
+      return (navigator.userAgentData as { mobile: boolean }).mobile === true;
+    }
+
+    // Safari & Firefox fallback
+    const userAgent = navigator.userAgent;
+    if (/Android|iPhone|iPod/.test(userAgent)) return true;
+
+    return false;
+  })();
+
+  private static readonly needsTouchFallback = WebHaptics.isMobileDevice && !WebHaptics.supportsVibrationAPI;
+
+  static readonly isSupported: boolean = WebHaptics.isMobileDevice;
 
   async trigger(
     input: HapticInput = [{ duration: 25, intensity: 0.7 }],
     options?: TriggerOptions,
   ): Promise<void> {
+
+    if (!WebHaptics.isSupported && !this.debug) {
+      console.warn(`[web-haptics] Haptics not supported on this device.`,);
+      return;
+    }
+
     const normalized = normalizeInput(input);
     if (!normalized) return;
 
@@ -195,7 +215,7 @@ export class WebHaptics {
       navigator.vibrate(toVibratePattern(vibrations, defaultIntensity));
     }
 
-    if (!WebHaptics.supportsVibrationAPI || this.debug) {
+    if (WebHaptics.needsTouchFallback || this.debug) {
       this.ensureDOM();
       if (!this.hapticLabel) return;
 

--- a/packages/web-haptics/src/lib/web-haptics/index.ts
+++ b/packages/web-haptics/src/lib/web-haptics/index.ts
@@ -152,8 +152,13 @@ export class WebHaptics {
     this.showSwitch = options?.showSwitch ?? false;
   }
 
-  static readonly isSupported: boolean =
+  private static readonly supportsVibrationAPI: boolean =
     typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
+
+  static readonly isSupported: boolean =
+    typeof navigator !== "undefined" &&
+    (typeof navigator.vibrate === "function" ||
+      navigator.maxTouchPoints > 0);
 
   async trigger(
     input: HapticInput = [{ duration: 25, intensity: 0.7 }],
@@ -186,11 +191,11 @@ export class WebHaptics {
       }
     }
 
-    if (WebHaptics.isSupported) {
+    if (WebHaptics.supportsVibrationAPI) {
       navigator.vibrate(toVibratePattern(vibrations, defaultIntensity));
     }
 
-    if (!WebHaptics.isSupported || this.debug) {
+    if (!WebHaptics.supportsVibrationAPI || this.debug) {
       this.ensureDOM();
       if (!this.hapticLabel) return;
 
@@ -222,7 +227,7 @@ export class WebHaptics {
 
   cancel(): void {
     this.stopPattern();
-    if (WebHaptics.isSupported) {
+    if (WebHaptics.supportsVibrationAPI) {
       navigator.vibrate(0);
     }
   }

--- a/site/src/surfaces/docs/index.tsx
+++ b/site/src/surfaces/docs/index.tsx
@@ -61,7 +61,7 @@ const methods = [
   {
     signature: "WebHaptics.isSupported: boolean",
     description:
-      "Static property. Returns true if the device supports the Vibration API.",
+      "Static property. Returns true if the device supports haptics (touch devices such as iOS and Android)",
   },
 ];
 

--- a/site/src/surfaces/docs/index.tsx
+++ b/site/src/surfaces/docs/index.tsx
@@ -61,7 +61,7 @@ const methods = [
   {
     signature: "WebHaptics.isSupported: boolean",
     description:
-      "Static property. Returns true if the device supports haptics (touch devices such as iOS and Android)",
+      "Static property. Returns true if the device supports haptics (iPhone and Android). Returns false on iPad, desktops, and other non-mobile platforms.",
   },
 ];
 


### PR DESCRIPTION
`isSupported` is now expanded to handle all mobile devices with `navigator.maxTouchPoints > 0` instead of just detection of the VibrationApi.