### PR TITLE
feat(svelte): auto-destroy haptics on unmount

### DIFF
--- a/apps/svelte-example/src/App.svelte
+++ b/apps/svelte-example/src/App.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
-  import { createWebHaptics } from 'web-haptics/svelte';
+  import { createWebHaptics } from "web-haptics/svelte";
 
-  const { trigger, destroy } = createWebHaptics();
-  onDestroy(destroy);
+  const { trigger } = createWebHaptics();
 </script>
 
 <div class="container">

--- a/apps/svelte-example/src/App.svelte
+++ b/apps/svelte-example/src/App.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="container">
-  <button on:click={() => trigger()}>Tap me</button>
+  <button onclick={() => trigger()}>Tap me</button>
 </div>
 
 <style>

--- a/packages/web-haptics/src/svelte/createWebHaptics.ts
+++ b/packages/web-haptics/src/svelte/createWebHaptics.ts
@@ -1,3 +1,4 @@
+import { onDestroy } from "svelte";
 import { WebHaptics } from "../lib/web-haptics";
 import type {
   HapticInput,
@@ -14,6 +15,8 @@ export function createWebHaptics(options?: WebHapticsOptions) {
   const destroy = () => instance.destroy();
   const setDebug = (debug: boolean) => instance.setDebug(debug);
   const isSupported = WebHaptics.isSupported;
+
+  onDestroy(destroy);
 
   return { trigger, cancel, destroy, setDebug, isSupported };
 }

--- a/site/src/surfaces/usage/index.tsx
+++ b/site/src/surfaces/usage/index.tsx
@@ -29,9 +29,7 @@ const { trigger } = useWebHaptics();
 </template>`,
   svelte: `<script>
   import { createWebHaptics } from "web-haptics/svelte";
-  import { onDestroy } from "svelte";
-  const { trigger, destroy } = createWebHaptics();
-  onDestroy(destroy);
+  const { trigger } = createWebHaptics();
 </script>
 
 <button on:click={() => trigger()}>Tap me</button>`,

--- a/site/src/surfaces/usage/index.tsx
+++ b/site/src/surfaces/usage/index.tsx
@@ -32,7 +32,7 @@ const { trigger } = useWebHaptics();
   const { trigger } = createWebHaptics();
 </script>
 
-<button on:click={() => trigger()}>Tap me</button>`,
+<button onclick={() => trigger()}>Tap me</button>`,
 };
 
 const frameworks = [


### PR DESCRIPTION
Svelte usage currently requires manual cleanup with `onDestroy(destroy)`.

This moves that cleanup into `createWebHaptics`, so the Svelte wrapper handles instance cleanup automatically on component unmount.

Also updates the Svelte example and docs snippet to match.